### PR TITLE
fix for python3 print and rstrip->strip

### DIFF
--- a/pySim-read.py
+++ b/pySim-read.py
@@ -129,7 +129,7 @@ if __name__ == '__main__':
 		else:
 			print("PLMNsel: Can't read, response code = %s" % (sw,))
 	except Exception as e:
-		print "HPLMNAcT: Can't read file -- " + str(e)
+		print("HPLMNAcT: Can't read file -- " + str(e))
 
 	# EF.PLMNwAcT
 	try:
@@ -139,7 +139,7 @@ if __name__ == '__main__':
 		else:
 			print("PLMNwAcT: Can't read, response code = %s" % (sw,))
 	except Exception as e:
-		print "PLMNwAcT: Can't read file -- " + str(e)
+		print("PLMNwAcT: Can't read file -- " + str(e))
 
 	# EF.OPLMNwAcT
 	try:
@@ -149,7 +149,7 @@ if __name__ == '__main__':
 		else:
 			print("OPLMNwAcT: Can't read, response code = %s" % (sw,))
 	except Exception as e:
-		print "OPLMNwAcT: Can't read file -- " + str(e)
+		print("OPLMNwAcT: Can't read file -- " + str(e))
 
 	# EF.HPLMNAcT
 	try:
@@ -159,7 +159,7 @@ if __name__ == '__main__':
 		else:
 			print("HPLMNAcT: Can't read, response code = %s" % (sw,))
 	except Exception as e:
-		print "HPLMNAcT: Can't read file -- " + str(e)
+		print("HPLMNAcT: Can't read file -- " + str(e))
 
 	# EF.ACC
 	(res, sw) = scc.read_binary(['3f00', '7f20', '6f78'])
@@ -180,7 +180,7 @@ if __name__ == '__main__':
 		else:
 			print("MSISDN: Can't read, response code = %s" % (sw,))
 	except Exception as e:
-		print "MSISDN: Can't read file -- " + str(e)
+		print("MSISDN: Can't read file -- " + str(e))
 
 	# EF.AD
 	(res, sw) = scc.read_binary(['3f00', '7f20', '6fad'])
@@ -190,4 +190,4 @@ if __name__ == '__main__':
 		print("AD: Can't read, response code = %s" % (sw,))
 
 	# Done for this card and maybe for everything ?
-	print "Done !\n"
+	print("Done !\n")

--- a/pySim/transport/serial.py
+++ b/pySim/transport/serial.py
@@ -162,7 +162,7 @@ class SerialSimLink(LinkBase):
 
 	def _dbg_print(self, s):
 		if self._debug:
-			print s
+			print(s)
 
 	def _tx_byte(self, b):
 		self._sl.write(b)

--- a/pySim/utils.py
+++ b/pySim/utils.py
@@ -80,7 +80,7 @@ def dec_imsi(ef):
 		return None
 	l = int(ef[0:2], 16) * 2		# Length of the IMSI string
 	l = l - 1						# Encoded length byte includes oe nibble
-	swapped = swap_nibbles(ef[2:]).rstrip('f')
+	swapped = swap_nibbles(ef[2:]).strip('f')
 	oe = (int(swapped[0])>>3) & 1	# Odd (1) / Even (0)
 	if not oe:
 		# if even, only half of last byte was used


### PR DESCRIPTION
After changing this, worked.

Before:
![image](https://user-images.githubusercontent.com/11086148/71915954-d8a11e00-314a-11ea-8c2a-21fb3acbc5cd.png)

After:
![image](https://user-images.githubusercontent.com/11086148/71915910-b60f0500-314a-11ea-9b9d-28a8e62fa9fc.png)
