### PR TITLE
Use zero padding for EF['ACC'] field

### DIFF
--- a/pySim/cards.py
+++ b/pySim/cards.py
@@ -76,7 +76,8 @@ class Card(object):
 		return sw
 
 	def update_acc(self, acc):
-		data, sw = self._scc.update_binary(EF['ACC'], lpad(acc, 4))
+		#data, sw = self._scc.update_binary(EF['ACC'], lpad(acc, 4))
+		data, sw = self._scc.update_binary(EF['ACC'], lpad(acc, 4, c='0'))
 		return sw
 
 	def read_hplmn_act(self):


### PR DESCRIPTION
The ``EF_ACC`` field defines the access control class (ACC) for a subscriber.

Current implementation adds padding 1 towards the most significant bits if the input is shorter than 2 bytes.

However, it should be padded with 0, otherwise additional ACCs are allocated to the subscriber. (Probably only a single bit shall be set to 1)

Excerpt from [ETSI TS 131 102, 4.2.15](https://www.etsi.org/deliver/etsi_ts/131100_131199/131102/04.15.00_60/ts_131102v041500p.pdf):

```
EF_ACC: Two bytes: B1, B2

B1.b8...B1.b4: high priority users (class 15...11)
B1.b3: always 0
B1.b2...B1.b2 and B2.b7...B2.b0: normal priority users (class 9...0) - to be evenly distributed across subscribers
```

**Legend:** Byte X, bit Y: BX.bY
