### PR TITLE
Set uSIM to 'type approval operations' in EF['AD']

### DIFF
--- a/pySim/cards.py
+++ b/pySim/cards.py
@@ -167,7 +167,8 @@ class Card(object):
 		if data.lower() == "ffffffff":
 			data = "00000000"
 
-		content = data[0:6] + "%02X" % mnclen
+		# content = data[0:6] + "%02X" % mnclen
+		content = "80" + data[2:6] + "%02X" % mnclen
 		data, sw = self._scc.update_binary(EF['AD'], content)
 		return sw
 


### PR DESCRIPTION
The ``EF_AD`` field contains administrative data (AD).
It consists of four bytes ``B1``, ``B2``, ``B3``, ``B4``, and optionally further bytes for future use.

Current implementation only sets the MNC field appropriately (located in `B4`) and sets all other bits/bytes to 0.

However, `B1` defines the *UE operation mode* as listed below. For type approval operations (such as testing with a test uSIM), this value should be set to `0x80` rather than `0x00`(= normal operation).
This may unlock some UE capabilities that are restricted in normal operation mode.

Excerpt from [ETSI TS 131 102, 4.2.18](https://www.etsi.org/deliver/etsi_ts/131100_131199/131102/04.15.00_60/ts_131102v041500p.pdf):

```
B1 - UE operation mode:
	Coding:
	Initial value
	- '00' normal operation.
	- '80' type approval operations.
	- '01' normal operation + specific facilities.
	- '81' type approval operations + specific facilities.
	- '02' maintenance (off line).
	- '04' cell test operation. 

B2 - Additional information:
	Coding:
	Reserved for future use

B3 - Additional information:
	Coding:
	- B3.b1: OFM setting (Ciphering)
	- B3.others: Reserved for future use
	
B4 - Length of MNC in the IMSI:
	Coding:
	- B4.b4..B4.b1: length:  '0010' (= 2) or '0011' (=3)
	- B4.others: Reserved for future use
```

**Legend:** Byte X, bit Y: BX.bY

Further reading: https://nickvsnetworking.com/usim-basics/
