### PR TITLE
fix invalid dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyscard
-serial
+pyserial
 pytlv
 cmd2==1.5
 jsonpath-ng


### PR DESCRIPTION
* serial is according to pypi: "A framework for serializing/deserializing
 JSON/YAML/XML into python class instances and vice versa"