### PR TITLE
Add pyyaml dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ jsonpath-ng
 construct
 bidict
 gsm0338
+pyyaml


### PR DESCRIPTION
Without pyyaml the execution of pySim-prog.py fails.

```
  File "C:\Users\jle\Github\pysim\pySim-prog.py", line 41, in <module>
    from pySim.card_handler import *
  File "C:\Users\jle\Github\pysim\pySim\card_handler.py", line 31, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```