### PR TITLE
Fix typos

### DIFF
--- a/contrib/es2p_client.py
+++ b/contrib/es2p_client.py
@@ -24,7 +24,7 @@ ICCID_HELP='The ICCID of the eSIM that shall be made available'
 MATCHID_HELP='MatchingID that shall be used by profile download'
 
 parser = argparse.ArgumentParser(description="""
-Utility to manuall issue requests against the ES2+ API of an SM-DP+ according to GSMA SGP.22.""")
+Utility to manually issue requests against the ES2+ API of an SM-DP+ according to GSMA SGP.22.""")
 parser.add_argument('--url', required=True, help='Base URL of ES2+ API endpoint')
 parser.add_argument('--id', required=True, help='Entity identifier passed to SM-DP+')
 parser.add_argument('--client-cert', help='X.509 client certificate used to authenticate to server')
@@ -63,7 +63,7 @@ if __name__ == '__main__':
     data = {}
     for k, v in vars(opts).items():
         if k in ['url', 'id', 'client_cert', 'server_ca_cert', 'command']:
-            # remove keys from dict that shold not end up in JSON...
+            # remove keys from dict that should not end up in JSON...
             continue
         if v is not None:
             data[k] = v

--- a/contrib/es9p_client.py
+++ b/contrib/es9p_client.py
@@ -68,7 +68,7 @@ parser_dl.add_argument('--confirmation-code',
 # notification
 parser_ntf = subparsers.add_parser('notification', help='ES9+ (other) notification')
 parser_ntf.add_argument('operation', choices=['enable','disable','delete'],
-                        help='Profile Management Opreation whoise occurrence shall be notififed')
+                        help='Profile Management Operation whoise occurrence shall be notififed')
 parser_ntf.add_argument('--sequence-nr', type=int, required=True,
                         help='eUICC global notification sequence number')
 parser_ntf.add_argument('--notification-address', help='notificationAddress, if different from URL')

--- a/contrib/saip-tool.py
+++ b/contrib/saip-tool.py
@@ -56,7 +56,7 @@ parser_rpe.add_argument('--output-file', required=True, help='Output file name')
 parser_rpe.add_argument('--identification', default=[], type=int, action='append', help='Remove PEs matching specified identification')
 parser_rpe.add_argument('--type', default=[], action='append', help='Remove PEs matching specified type')
 
-parser_rn = subparsers.add_parser('remove-naa', help='Remove speciifed NAAs from PE-Sequence')
+parser_rn = subparsers.add_parser('remove-naa', help='Remove specified NAAs from PE-Sequence')
 parser_rn.add_argument('--output-file', required=True, help='Output file name')
 parser_rn.add_argument('--naa-type', required=True, choices=NAAs.keys(), help='Network Access Application type to remove')
 # TODO: add an --naa-index or the like, so only one given instance can be removed

--- a/contrib/saip-tool_example_add-app.sh
+++ b/contrib/saip-tool_example_add-app.sh
@@ -27,5 +27,5 @@ PYTHONPATH=$PYSIMPATH python3 $PYSIMPATH/contrib/saip-tool.py $OUTPATH add-app-i
 # Display the contents of the resulting application PE:
 PYTHONPATH=$PYSIMPATH python3 $PYSIMPATH/contrib/saip-tool.py $OUTPATH info --apps
 
-# For an explaination of --uicc-toolkit-app-spec-pars, see:
+# For an explanation of --uicc-toolkit-app-spec-pars, see:
 # ETSI TS 102 226, section 8.2.1.3.2.2.1

--- a/contrib/unber.py
+++ b/contrib/unber.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# A more useful verion of the 'unber' tool provided with asn1c:
+# A more useful version of the 'unber' tool provided with asn1c:
 # Give a hierarchical decode of BER/DER-encoded ASN.1 TLVs
 
 import sys

--- a/docs/legacy.rst
+++ b/docs/legacy.rst
@@ -49,7 +49,7 @@ Two modes are possible:
     Ki and OPc will be generated during each programming cycle. This means fresh keys are generated, even when the
     ``--num`` remains unchanged.
 
-    The parameter ``--num`` specifies a card individual number. This number will be manged into the random seed so that
+    The parameter ``--num`` specifies a card individual number. This number will be managed into the random seed so that
     it serves as an identifier for a particular set of randomly generated parameters.
 
     In the example above the parameters ``--mcc``, and ``--mnc`` are specified as well, since they identify the GSM
@@ -77,7 +77,7 @@ the parameter ``--type``. The following card types are supported:
 
 Specifying the card reader:
 
-It is most common to use ``pySim-prog`` together whith a PCSC reader. The PCSC reader number is specified via the
+It is most common to use ``pySim-prog`` together with a PCSC reader. The PCSC reader number is specified via the
 ``--pcsc-device`` or ``-p`` option. However, other reader types (such as serial readers and modems) are supported. Use
 the ``--help`` option of ``pySim-prog`` for more information.
 

--- a/docs/osmo-smdpp.rst
+++ b/docs/osmo-smdpp.rst
@@ -21,9 +21,9 @@ osmo-smdpp currently
 
 * [by default] uses test certificates copied from GSMA SGP.26 into `./smdpp-data/certs`, assuming that your
   osmo-smdpp would be running at the host name `testsmdpplus1.example.com`. You can of course replace those
-  certificates with your own, whether SGP.26 derived or part of a *private root CA* setup with mathcing eUICCs.
+  certificates with your own, whether SGP.26 derived or part of a *private root CA* setup with matching eUICCs.
 * doesn't understand profile state. Any profile can always be downloaded any number of times, irrespective
-  of the EID or whether it was donwloaded before.  This is actually very useful for R&D and testing, as it
+  of the EID or whether it was downloaded before.  This is actually very useful for R&D and testing, as it
   doesn't require you to generate new profiles all the time.  This logic of course is unsuitable for
   production usage.
 * doesn't perform any personalization, so the IMSI/ICCID etc. are always identical (the ones that are stored in

--- a/docs/sim-rest.rst
+++ b/docs/sim-rest.rst
@@ -75,7 +75,7 @@ The response body is a JSON document, either
    #. key freshness failure
    #. unspecified card error
 
-Example (succcess):
+Example (success):
 ::
 
         {

--- a/docs/suci-tutorial.rst
+++ b/docs/suci-tutorial.rst
@@ -30,7 +30,7 @@ This guide covers the basic workflow of provisioning SIM cards with the 5G SUCI 
 
 For specific information on sysmocom SIM cards, refer to
 
-* the `sysmoISIM-SJA5 User Manual <https://sysmocom.de/manuals/sysmoisim-sja5-manual.pdf>`__ for the curent
+* the `sysmoISIM-SJA5 User Manual <https://sysmocom.de/manuals/sysmoisim-sja5-manual.pdf>`__ for the current
   sysmoISIM-SJA5 product
 * the `sysmoISIM-SJA2 User Manual <https://sysmocom.de/manuals/sysmousim-manual.pdf>`__ for the older
   sysmoISIM-SJA2 product

--- a/osmo-smdpp.py
+++ b/osmo-smdpp.py
@@ -651,7 +651,7 @@ class SmDppHttpServer:
             # there's currently no other option in the ctxParams1 choice, so this cannot happen
             raise ApiError('1.3.1', '2.2', 'ctxParams1 missing mandatory ctxParamsForCommonAuthentication')
 
-        # FIXME: we actually want to perform the profile binding herr, and read the profile metadat from the profile
+        # FIXME: we actually want to perform the profile binding herr, and read the profile metadata from the profile
 
         # Put together profileMetadata + _bin
         ss.profileMetadata = ProfileMetadata(iccid_bin=h2b(swap_nibbles(iccid_str)), spn="OsmocomSPN", profile_name=matchingId)
@@ -738,14 +738,14 @@ class SmDppHttpServer:
         #  Perform actual protection + binding of profile package (or return  pre-bound one)
         with open(os.path.join(self.upp_dir, ss.matchingId)+'.der', 'rb') as f:
             upp = UnprotectedProfilePackage.from_der(f.read(), metadata=ss.profileMetadata)
-            # HACK: Use empty PPP as we're still debuggin the configureISDP step, and we want to avoid
+            # HACK: Use empty PPP as we're still debugging the configureISDP step, and we want to avoid
             # cluttering the log with stuff happening after the failure
             #upp = UnprotectedProfilePackage.from_der(b'', metadata=ss.profileMetadata)
         if False:
             # Use random keys
             bpp = BoundProfilePackage.from_upp(upp)
         else:
-            # Use sesssion keys
+            # Use session keys
             ppp = ProtectedProfilePackage.from_upp(upp, BspInstance(b'\x00'*16, b'\x11'*16, b'\x22'*16))
             bpp = BoundProfilePackage.from_ppp(ppp)
 

--- a/pySim-prog.py
+++ b/pySim-prog.py
@@ -586,7 +586,7 @@ def read_params_csv(opts, imsi=None, iccid=None):
         else:
             row['mnc'] = row.get('mnc', mnc_from_imsi(row.get('imsi'), False))
 
-	# NOTE: We might concider to specify a new CSV field "mnclen" in our
+	# NOTE: We might consider to specify a new CSV field "mnclen" in our
 	# CSV files for a better automatization. However, this only makes sense
 	# when the tools and databases we export our files from will also add
 	# such a field.

--- a/pySim-read.py
+++ b/pySim-read.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Utility to display some informations about a SIM card
+# Utility to display some information about a SIM card
 #
 #
 # Copyright (C) 2009  Sylvain Munaut <tnt@246tNt.com>

--- a/pySim-shell.py
+++ b/pySim-shell.py
@@ -265,7 +265,7 @@ Online manual available at https://downloads.osmocom.org/docs/pysim/master/html/
     def do_apdu(self, opts):
         """Send a raw APDU to the card, and print SW + Response.
         CAUTION: this command bypasses the logical channel handling of pySim-shell and card state changes are not
-        tracked. Dpending on the raw APDU sent, pySim-shell may not continue to work as expected if you e.g. select
+        tracked. Depending on the raw APDU sent, pySim-shell may not continue to work as expected if you e.g. select
         a different file."""
 
         # When sending raw APDUs we access the scc object through _scc member of the card object. It should also be
@@ -336,7 +336,7 @@ Online manual available at https://downloads.osmocom.org/docs/pysim/master/html/
 
     def _process_card(self, first, script_path):
 
-        # Early phase of card initialzation (this part may fail with an exception)
+        # Early phase of card initialization (this part may fail with an exception)
         try:
             rs, card = init_card(self.sl)
             rc = self.equip(card, rs)
@@ -377,7 +377,7 @@ Online manual available at https://downloads.osmocom.org/docs/pysim/master/html/
 
     bulk_script_parser = argparse.ArgumentParser()
     bulk_script_parser.add_argument('SCRIPT_PATH', help="path to the script file")
-    bulk_script_parser.add_argument('--halt_on_error', help='stop card handling if an exeption occurs',
+    bulk_script_parser.add_argument('--halt_on_error', help='stop card handling if an exception occurs',
                                     action='store_true')
     bulk_script_parser.add_argument('--tries', type=int, default=2,
                                     help='how many tries before trying the next card')
@@ -731,7 +731,7 @@ class PySimCommands(CommandSet):
                     body = {}
                     for t in tags:
                         result = self._cmd.lchan.retrieve_data(t)
-                        (tag, l, val, remainer) = bertlv_parse_one(h2b(result[0]))
+                        (tag, l, val, remainder) = bertlv_parse_one(h2b(result[0]))
                         body[t] = b2h(val)
                 else:
                     raise RuntimeError('Unsupported structure "%s" of file "%s"' % (structure, filename))

--- a/pySim-smpp2sim.py
+++ b/pySim-smpp2sim.py
@@ -84,7 +84,7 @@ def tcp_connected_callback(p: protocol.Protocol):
     logger.error("%s: connected!" % p)
 
 class ProactChannel:
-    """Representation of a single proective channel."""
+    """Representation of a single protective channel."""
     def __init__(self, channels: 'ProactChannels', chan_nr: int):
         self.channels = channels
         self.chan_nr = chan_nr

--- a/pySim-trace.py
+++ b/pySim-trace.py
@@ -151,7 +151,7 @@ global_group.add_argument('--no-suppress-select', action='store_false', dest='su
 global_group.add_argument('--no-suppress-status', action='store_false', dest='suppress_status',
                           help="""
     Don't suppress displaying STATUS APDUs. We normally suppress them as they don't provide any
-    information that was not already received in resposne to the most recent SEELCT.""")
+    information that was not already received in response to the most recent SEELCT.""")
 global_group.add_argument('--show-raw-apdu', action='store_true', dest='show_raw_apdu',
                           help="""Show the raw APDU in addition to its parsed form.""")
 
@@ -188,7 +188,7 @@ parser_rspro_pyshark_live.add_argument('-i', '--interface', required=True,
 parser_tcaloader_log = subparsers.add_parser('tca-loader-log', help="""
     Read APDUs from a TCA Loader log file.""")
 parser_tcaloader_log.add_argument('-f', '--log-file', required=True,
-                                  help='Name of te log file to be read')
+                                  help='Name of the log file to be read')
 
 if __name__ == '__main__':
 

--- a/pySim/ara_m.py
+++ b/pySim/ara_m.py
@@ -317,7 +317,7 @@ class ADF_ARAM(CardADF):
         store_ref_ar_do_parse = argparse.ArgumentParser()
         # REF-DO
         store_ref_ar_do_parse.add_argument(
-            '--device-app-id', required=True, help='Identifies the specific device application that the rule appplies to. Hash of Certificate of Application Provider, or UUID. (20/32 hex bytes)')
+            '--device-app-id', required=True, help='Identifies the specific device application that the rule applies to. Hash of Certificate of Application Provider, or UUID. (20/32 hex bytes)')
         aid_grp = store_ref_ar_do_parse.add_mutually_exclusive_group()
         aid_grp.add_argument(
             '--aid', help='Identifies the specific SE application for which rules are to be stored. Can be a partial AID, containing for example only the RID. (5-16 or 0 hex bytes)')
@@ -399,7 +399,7 @@ class ADF_ARAM(CardADF):
 sw_aram = {
     'ARA-M': {
         '6381': 'Rule successfully stored but an access rule already exists',
-        '6382': 'Rule successfully stored bu contained at least one unknown (discarded) BER-TLV',
+        '6382': 'Rule successfully stored but contained at least one unknown (discarded) BER-TLV',
         '6581': 'Memory Problem',
         '6700': 'Wrong Length in Lc',
         '6981': 'DO is not supported by the ARA-M/ARA-C',

--- a/pySim/card_key_provider.py
+++ b/pySim/card_key_provider.py
@@ -163,7 +163,7 @@ def card_key_provider_register(provider: CardKeyProvider, provider_list=card_key
             provider_list : override the list of providers from the global default
     """
     if not isinstance(provider, CardKeyProvider):
-        raise ValueError("provider is not a card data provier")
+        raise ValueError("provider is not a card data provider")
     provider_list.append(provider)
 
 
@@ -181,7 +181,7 @@ def card_key_provider_get(fields, key: str, value: str, provider_list=card_key_p
     for p in provider_list:
         if not isinstance(p, CardKeyProvider):
             raise ValueError(
-                "provider list contains element which is not a card data provier")
+                "provider list contains element which is not a card data provider")
         result = p.get(fields, key, value)
         if result:
             return result
@@ -202,7 +202,7 @@ def card_key_provider_get_field(field: str, key: str, value: str, provider_list=
     for p in provider_list:
         if not isinstance(p, CardKeyProvider):
             raise ValueError(
-                "provider list contains element which is not a card data provier")
+                "provider list contains element which is not a card data provider")
         result = p.get_field(field, key, value)
         if result:
             return result

--- a/pySim/cat.py
+++ b/pySim/cat.py
@@ -316,19 +316,19 @@ class FileList(COMPR_TLV_IE, tag=0x92):
     _construct = Struct('number_of_files'/Int8ub,
                         'files'/GreedyRange(FileId))
 
-# TS 102 223 Secton 8.19
+# TS 102 223 Section 8.19
 class LocationInformation(COMPR_TLV_IE, tag=0x93):
     pass
 
-# TS 102 223 Secton 8.20
+# TS 102 223 Section 8.20
 class IMEI(COMPR_TLV_IE, tag=0x94):
     _construct = BcdAdapter(GreedyBytes)
 
-# TS 102 223 Secton 8.21
+# TS 102 223 Section 8.21
 class HelpRequest(COMPR_TLV_IE, tag=0x95):
     pass
 
-# TS 102 223 Secton 8.22
+# TS 102 223 Section 8.22
 class NetworkMeasurementResults(COMPR_TLV_IE, tag=0x96):
     _construct = BcdAdapter(GreedyBytes)
 

--- a/pySim/commands.py
+++ b/pySim/commands.py
@@ -285,7 +285,7 @@ class SimCardCommands:
         return self.send_apdu_checksw(self.cla_byte + "a40304")
 
     def select_adf(self, aid: Hexstr) -> ResTuple:
-        """Execute SELECT a given Applicaiton ADF.
+        """Execute SELECT a given Application ADF.
 
         Args:
                 aid : application identifier as hex string
@@ -577,7 +577,7 @@ class SimCardCommands:
 
         Args:
                 rand : 16 byte random data as hex string (RAND)
-                autn : 8 byte Autentication Token (AUTN)
+                autn : 8 byte Authentication Token (AUTN)
                 context : 16 byte random data ('3g' or 'gsm')
         """
         # 3GPP TS 31.102 Section 7.1.2.1

--- a/pySim/esim/es2p.py
+++ b/pySim/esim/es2p.py
@@ -116,7 +116,7 @@ class param:
         pass
 
 class Es2PlusApiFunction(JsonHttpApiFunction):
-    """Base classs for representing an ES2+ API Function."""
+    """Base class for representing an ES2+ API Function."""
     pass
 
 # ES2+ DownloadOrder function (SGP.22 section 5.3.1)

--- a/pySim/esim/es9p.py
+++ b/pySim/esim/es9p.py
@@ -1,4 +1,4 @@
-"""GSMA eSIM RSP ES9+ interface according ot SGP.22 v2.5"""
+"""GSMA eSIM RSP ES9+ interface according to SGP.22 v2.5"""
 
 # (C) 2024 by Harald Welte <laforge@osmocom.org>
 #

--- a/pySim/esim/http_json_api.py
+++ b/pySim/esim/http_json_api.py
@@ -159,7 +159,7 @@ class ApiError(Exception):
         return f'{self.status}("{self.subject_code}","{self.reason_code}","{self.subject_id}","{self.message}")'
 
 class JsonHttpApiFunction(abc.ABC):
-    """Base classs for representing an HTTP[s] API Function."""
+    """Base class for representing an HTTP[s] API Function."""
      # the below class variables are expected to be overridden in derived classes
 
     path = None

--- a/pySim/esim/rsp.py
+++ b/pySim/esim/rsp.py
@@ -90,7 +90,7 @@ class RspSessionState:
             # FIXME: how to add the public key from smdp_otpk to an instance of EllipticCurvePrivateKey?
             del state['_smdp_otsk']
             del state['_smdp_ot_curve']
-        # automatically recover all the remainig state
+        # automatically recover all the remaining state
         self.__dict__.update(state)
 
 

--- a/pySim/esim/saip/__init__.py
+++ b/pySim/esim/saip/__init__.py
@@ -334,7 +334,7 @@ class File:
                     self.fill_pattern = pefi['fillPattern']
                     self.fill_pattern_repeat = False
             elif fdb_dec['file_type'] == 'df':
-                # only set it, if an earlier call to from_template() didn't alrady set it, as
+                # only set it, if an earlier call to from_template() didn't already set it, as
                 # the template can differentiate between MF, DF and ADF (unlike FDB)
                 if not self.file_type:
                     self.file_type = 'DF'
@@ -427,7 +427,7 @@ class File:
 
 class ProfileElement:
     """Generic Class representing a Profile Element (PE) within a SAIP Profile. This may be used directly,
-    but ist more likely sub-classed with a specific class for the specific profile element type, like e.g
+    but it's more likely sub-classed with a specific class for the specific profile element type, like e.g
     ProfileElementHeader, ProfileElementMF, ...
     """
     FILE_BEARING = ['mf', 'cd', 'telecom', 'usim', 'opt-usim', 'isim', 'opt-isim', 'phonebook', 'gsm-access',
@@ -440,7 +440,7 @@ class ProfileElement:
         'genericFileManagement':    'gfm-header',
         'akaParameter':             'aka-header',
         'cdmaParameter':            'cdma-header',
-        # note how they couldn't even consistently captialize the 'header' suffix :(
+        # note how they couldn't even consistently capitalize the 'header' suffix :(
         'application':              'app-Header',
         'pukCodes':                 'puk-Header',
         'pinCodes':                 'pin-Header',
@@ -628,7 +628,7 @@ class FsProfileElement(ProfileElement):
                     # this is a template that belongs into the [A]DF of another template
                     # 1) find the PE for the referenced template
                     parent_pe = self.pe_sequence.get_closest_prev_pe_for_templateID(self, template.parent.oid)
-                    # 2) resolve te [A]DF that forms the base of that parent PE
+                    # 2) resolve the [A]DF that forms the base of that parent PE
                     pe_df = parent_pe.files[template.parent.base_df().pe_name].node
                     self.pe_sequence.cur_df = pe_df
                 self.pe_sequence.cur_df = self.pe_sequence.cur_df.add_file(file)
@@ -649,7 +649,7 @@ class FsProfileElement(ProfileElement):
                 self.add_file(file)
 
     def create_file(self, pename: str) -> File:
-        """Programatically create a file by its PE-Name."""
+        """Programmatically create a file by its PE-Name."""
         template = templates.ProfileTemplateRegistry.get_by_oid(self.templateID)
         file = File(pename, None, template.files_by_pename.get(pename, None))
         self.add_file(file)
@@ -1409,7 +1409,7 @@ class ProfileElementHeader(ProfileElement):
                  iccid: Optional[Hexstr] = '0'*20, profile_type: Optional[str] = None,
                  **kwargs):
         """You would usually initialize an instance either with a "decoded" argument (as read from
-        a DER-encoded SAIP file via asn1tools), or [some of] the othe arguments in case you're
+        a DER-encoded SAIP file via asn1tools), or [some of] the other arguments in case you're
         constructing a Profile Header from scratch.
 
         Args:
@@ -1562,7 +1562,7 @@ class ProfileElementSequence:
 
     def _rebuild_pes_by_naa(self) -> None:
         """rebuild the self.pes_by_naa dict {naa: [ [pe, pe, pe], [pe, pe] ]} form,
-        which basically means for every NAA there's a lsit of instances, and each consists
+        which basically means for every NAA there's a list of instances, and each consists
         of a list of a list of PEs."""
         self.pres_by_naa = {}
         petype_not_naa_related = ['securityDomain', 'rfm', 'application', 'end']
@@ -1690,7 +1690,7 @@ class ProfileElementSequence:
             i += 1
 
     def get_index_by_pe(self, pe: ProfileElement) -> int:
-        """Return a list with the indicies of all instances of PEs of petype."""
+        """Return a list with the indices of all instances of PEs of petype."""
         ret = []
         i = 0
         for cur in self.pe_list:
@@ -1711,7 +1711,7 @@ class ProfileElementSequence:
         self.insert_at_index(idx+1, pe_new)
 
     def get_index_by_type(self, petype: str) -> List[int]:
-        """Return a list with the indicies of all instances of PEs of petype."""
+        """Return a list with the indices of all instances of PEs of petype."""
         ret = []
         i = 0
         for pe in self.pe_list:
@@ -1736,7 +1736,7 @@ class ProfileElementSequence:
         for service in naa.mandatory_services:
             if service in hdr.decoded['eUICC-Mandatory-services']:
                 del hdr.decoded['eUICC-Mandatory-services'][service]
-        # remove any associaed mandatory filesystem templates
+        # remove any associated mandatory filesystem templates
         for template in naa.templates:
             if template in hdr.decoded['eUICC-Mandatory-GFSTEList']:
                 hdr.decoded['eUICC-Mandatory-GFSTEList'] = [x for x in hdr.decoded['eUICC-Mandatory-GFSTEList'] if not template.prefix_match(x)]

--- a/pySim/esim/saip/validation.py
+++ b/pySim/esim/saip/validation.py
@@ -68,7 +68,7 @@ class CheckBasicStructure(ProfileConstraintChecker):
 
     def check_optional_ordering(self, pes: ProfileElementSequence):
         """Check the ordering of optional PEs following the respective mandatory ones."""
-        # ordering and required depenencies
+        # ordering and required dependencies
         self._is_after_if_exists(pes,'opt-usim', 'usim')
         self._is_after_if_exists(pes,'opt-isim', 'isim')
         self._is_after_if_exists(pes,'gsm-access', 'usim')

--- a/pySim/filesystem.py
+++ b/pySim/filesystem.py
@@ -86,7 +86,7 @@ class CardFile:
         self.service = service
         self.shell_commands = []  # type: List[CommandSet]
 
-        # Note: the basic properties (fid, name, ect.) are verified when
+        # Note: the basic properties (fid, name, etc.) are verified when
         # the file is attached to a parent file. See method add_file() in
         # class Card DF
 
@@ -266,7 +266,7 @@ class CardFile:
     def get_profile(self):
         """Get the profile associated with this file. If this file does not have any
         profile assigned, try to find a file above (usually the MF) in the filesystem
-        hirarchy that has a profile assigned
+        hierarchy that has a profile assigned
         """
 
         # If we have a profile set, return it
@@ -679,7 +679,7 @@ class TransparentEF(CardEF):
         Args:
             fid : File Identifier (4 hex digits)
             sfid : Short File Identifier (2 hex digits, optional)
-            name : Brief name of the file, lik EF_ICCID
+            name : Brief name of the file, like EF_ICCID
             desc : Description of the file
             parent : Parent CardFile object within filesystem hierarchy
             size : tuple of (minimum_size, recommended_size)
@@ -982,11 +982,11 @@ class LinFixedEF(CardEF):
         Args:
             fid : File Identifier (4 hex digits)
             sfid : Short File Identifier (2 hex digits, optional)
-            name : Brief name of the file, lik EF_ICCID
+            name : Brief name of the file, like EF_ICCID
             desc : Description of the file
             parent : Parent CardFile object within filesystem hierarchy
             rec_len : Tuple of (minimum_length, recommended_length)
-            leftpad: On write, data must be padded from the left to fit pysical record length
+            leftpad: On write, data must be padded from the left to fit physical record length
         """
         super().__init__(fid=fid, sfid=sfid, name=name, desc=desc, parent=parent, **kwargs)
         self.rec_len = rec_len
@@ -1422,7 +1422,7 @@ class BerTlvEF(CardEF):
         Args:
             fid : File Identifier (4 hex digits)
             sfid : Short File Identifier (2 hex digits, optional)
-            name : Brief name of the file, lik EF_ICCID
+            name : Brief name of the file, like EF_ICCID
             desc : Description of the file
             parent : Parent CardFile object within filesystem hierarchy
             size : tuple of (minimum_size, recommended_size)
@@ -1455,7 +1455,7 @@ class BerTlvEF(CardEF):
             export_str += "delete_all\n"
             for t in tags:
                 result = lchan.retrieve_data(t)
-                (tag, l, val, remainer) = bertlv_parse_one(h2b(result[0]))
+                (tag, l, val, remainder) = bertlv_parse_one(h2b(result[0]))
                 export_str += ("set_data 0x%02x %s\n" % (t, b2h(val)))
         return export_str.strip()
 
@@ -1495,7 +1495,7 @@ class CardApplication:
         self.name = name
         self.adf = adf
         self.sw = sw or {}
-        # back-reference from ADF to Applicaiton
+        # back-reference from ADF to Application
         if self.adf:
             self.aid = aid or self.adf.aid
             self.adf.application = self
@@ -1572,7 +1572,7 @@ class Path:
             p = p.split('/')
         elif len(p) and isinstance(p[0], int):
             p = ['%04x' % x for x in p]
-        # make sure internal representation alwas is uppercase only
+        # make sure internal representation always is uppercase only
         self.list = [x.upper() for x in p]
 
     def __str__(self) -> str:

--- a/pySim/global_platform/__init__.py
+++ b/pySim/global_platform/__init__.py
@@ -627,7 +627,7 @@ class ADF_SD(CardADF):
                     kcv_bin = compute_kcv(opts.key_type[i], h2b(opts.key_data[i])) or b''
                     kcv = b2h(kcv_bin)
                 if self._cmd.lchan.scc.scp:
-                    # encrypte key data with DEK of current SCP
+                    # encrypted key data with DEK of current SCP
                     kcb = b2h(self._cmd.lchan.scc.scp.encrypt_key(h2b(opts.key_data[i])))
                 else:
                     # (for example) during personalization, DEK might not be required)
@@ -755,7 +755,7 @@ class ADF_SD(CardADF):
 
         inst_load_parser = argparse.ArgumentParser()
         inst_load_parser.add_argument('--load-file-aid', type=is_hexstr, required=True,
-                                      help='AID of the loded file')
+                                      help='AID of the loaded file')
         inst_load_parser.add_argument('--security-domain-aid', type=is_hexstr, default='',
                                       help='AID of the Security Domain into which the file shalle be added')
         inst_load_parser.add_argument('--load-file-hash', type=is_hexstr, default='',
@@ -845,7 +845,7 @@ class ADF_SD(CardADF):
             # TODO:tune chunk_len based on the overhead of the used SCP?
             # build TLV according to GPC_SPE_034 section 11.6.2.3 / Table 11-58 for unencrypted case
             remainder = b'\xC4' + bertlv_encode_len(len(contents)) + contents
-            # transfer this in vaious chunks to the card
+            # transfer this in various chunks to the card
             total_size = len(remainder)
             block_nr = 0
             while len(remainder):

--- a/pySim/global_platform/uicc.py
+++ b/pySim/global_platform/uicc.py
@@ -104,4 +104,4 @@ class UiccSdInstallParams(TLV_IE_Collection, nested=[UiccScp, AcceptExtradAppsAn
 #   KID 0x02: SK.CASD.AUT (PK) and KS.CASD.AUT (Non-PK)
 #   KID 0x03: SK.CASD.CT (P) and KS.CASD.CT (Non-PK)
 # KVN 0x75 KID 0x01: 16-byte DES key for  Ciphered Load File Data Block
-# KVN 0xFF reserved for ISD with SCP02 without SCP80 s upport
+# KVN 0xFF reserved for ISD with SCP02 without SCP80 s support

--- a/pySim/javacard.py
+++ b/pySim/javacard.py
@@ -97,7 +97,7 @@ class CapFile():
                 raise ValueError("invalid cap file, %s missing!" % required_components[component])
 
     def get_loadfile(self) -> bytes:
-        """Get the executeable loadfile as hexstring"""
+        """Get the executable loadfile as hexstring"""
         # Concatenate all cap file components in the specified order
         # see also: Java Card Platform Virtual Machine Specification, v3.2, section 6.3
         loadfile = self.__component['Header']

--- a/pySim/legacy/cards.py
+++ b/pySim/legacy/cards.py
@@ -495,7 +495,7 @@ class IsimCard(UiccCardBase):
 
 class MagicSimBase(abc.ABC, SimCard):
     """
-    Theses cards uses several record based EFs to store the provider infos,
+    These cards uses several record based EFs to store the provider infos,
     each possible provider uses a specific record number in each EF. The
     indexes used are ( where N is the number of providers supported ) :
      - [2 .. N+1] for the operator name
@@ -644,7 +644,7 @@ class MagicSim(MagicSimBase):
 
 class FakeMagicSim(SimCard):
     """
-    Theses cards have a record based EF 3f00/000c that contains the provider
+    These cards have a record based EF 3f00/000c that contains the provider
     information. See the program method for its format. The records go from
     1 to N.
     """

--- a/pySim/legacy/utils.py
+++ b/pySim/legacy/utils.py
@@ -296,7 +296,7 @@ def dec_addr_tlv(hexstr):
 
         elif addr_type == 0x01:  # IPv4
             # Skip address tye byte i.e. first byte in value list
-            # Skip the unused byte in Octect 4 after address type byte as per 3GPP TS 31.102
+            # Skip the unused byte in Octet 4 after address type byte as per 3GPP TS 31.102
             ipv4 = tlv[2][2:]
             content = '.'.join(str(x) for x in ipv4)
             return (content, '01')

--- a/pySim/profile.py
+++ b/pySim/profile.py
@@ -110,7 +110,7 @@ class CardProfile:
     @abc.abstractmethod
     def _try_match_card(cls, scc: SimCardCommands) -> None:
         """Try to see if the specific profile matches the card. This method is a
-        placeholder that is overloaded by specific dirived classes. The method
+        placeholder that is overloaded by specific derived classes. The method
         actively probes the card to make sure the profile class matches the
         physical card. This usually also means that the card is reset during
         the process, so this method must not be called at random times. It may

--- a/pySim/runtime.py
+++ b/pySim/runtime.py
@@ -150,7 +150,7 @@ class RuntimeState:
         # select MF to reset internal state and to verify card really works
         self.lchan[0].select('MF', cmd_app)
         self.lchan[0].selected_adf = None
-        # store ATR as part of our card identies dict
+        # store ATR as part of our card identities dict
         self.identity['ATR'] = atr
         return atr
 
@@ -324,7 +324,7 @@ class RuntimeLchan:
             # If we succeed, we know that the file exists on the card and we may
             # proceed with creating a new CardEF object in the local file model at
             # run time. In case the file does not exist on the card, we just abort.
-            # The state on the card (selected file/application) wont't be changed,
+            # The state on the card (selected file/application) won't be changed,
             # so we do not have to update any state in that case.
             (data, _sw) = self.scc.select_file(fid)
         except SwMatchError as swm:

--- a/pySim/secure_channel.py
+++ b/pySim/secure_channel.py
@@ -32,7 +32,7 @@ class SecureChannel(abc.ABC):
         pass
 
     def send_apdu_wrapper(self, send_fn: callable, pdu: Hexstr, *args, **kwargs) -> ResTuple:
-        """Wrapper function to wrap command APDU and unwrap repsonse APDU around send_apdu callable."""
+        """Wrapper function to wrap command APDU and unwrap response APDU around send_apdu callable."""
         pdu_wrapped = b2h(self.wrap_cmd_apdu(h2b(pdu)))
         res, sw = send_fn(pdu_wrapped, *args, **kwargs)
         res_unwrapped = b2h(self.unwrap_rsp_apdu(h2b(sw), h2b(res)))

--- a/pySim/transport/__init__.py
+++ b/pySim/transport/__init__.py
@@ -200,7 +200,7 @@ class LinkBase(abc.ABC):
             # It *was* successful after all -- the extra pieces FETCH handled
             # need not concern the caller.
             rv = (rv[0], '9000')
-            # proactive sim as per TS 102 221 Setion 7.4.2
+            # proactive sim as per TS 102 221 Section 7.4.2
             # TODO: Check SW manually to avoid recursing on the stack (provided this piece of code stays in this place)
             fetch_rv = self.send_apdu_checksw('80120000' + last_sw[2:], sw)
             # Setting this in case we later decide not to send a terminal
@@ -228,7 +228,7 @@ class LinkBase(abc.ABC):
             # Structure as per TS 102 223 V4.4.0 Section 6.8
 
             # Testing hint: The value of tail does not influence the behavior
-            # of an SJA2 that sent ans SMS, so this is implemented only
+            # of an SJA2 that sent an SMS, so this is implemented only
             # following TS 102 223, and not fully tested.
             ti_list_bin = [x.to_tlv() for x in ti_list]
             tail = b''.join(ti_list_bin)

--- a/pySim/ts_31_102.py
+++ b/pySim/ts_31_102.py
@@ -208,7 +208,7 @@ EF_5G_PROSE_ST_map = {
     5: '5G ProSe configuration data for usage information reporting',
 }
 
-# Mapping between USIM Enbled Service Number and its description
+# Mapping between USIM Enabled Service Number and its description
 EF_EST_map = {
     1: 'Fixed Dialling Numbers (FDN)',
     2: 'Barred Dialling Numbers (BDN)',

--- a/pySim/ts_31_103_shared.py
+++ b/pySim/ts_31_103_shared.py
@@ -119,7 +119,7 @@ class EF_AC_GBAUAPI(LinFixedEF):
     """The use of this EF is eescribed in 3GPP TS 31.130"""
     class AppletNafAccessControl(BER_TLV_IE, tag=0x80):
         # the use of Int8ub as length field in Prefixed is strictly speaking incorrect, as it is a BER-TLV
-        # length field whihc will consume two bytes from length > 127 bytes.  However, AIDs and NAF IDs can
+        # length field which will consume two bytes from length > 127 bytes.  However, AIDs and NAF IDs can
         # safely be assumed shorter than that
         _construct = Struct('aid'/Prefixed(Int8ub, GreedyBytes),
                             'naf_id'/Prefixed(Int8ub, GreedyBytes))

--- a/pySim/ts_51_011.py
+++ b/pySim/ts_51_011.py
@@ -1007,7 +1007,7 @@ class EF_ICCID(TransparentEF):
     def _encode_hex(self, abstract, **kwargs):
         return enc_iccid(abstract['iccid'])
 
-# TS 102 221 Section 13.3 / TS 31.101 Secction 13 / TS 51.011 Section 10.1.2
+# TS 102 221 Section 13.3 / TS 31.101 Section 13 / TS 51.011 Section 10.1.2
 class EF_PL(TransRecEF):
     _test_de_encode = [
         ( '6465', "de" ),

--- a/pySim/utils.py
+++ b/pySim/utils.py
@@ -331,7 +331,7 @@ def derive_mnc(digit1: int, digit2: int, digit3: int = 0x0f) -> int:
     mnc = 0
 
     # 3-rd digit is optional for the MNC. If present
-    # the algorythm is the same as for the MCC.
+    # the algorithm is the same as for the MCC.
     if digit3 != 0x0f:
         return derive_mcc(digit1, digit2, digit3)
 
@@ -411,7 +411,7 @@ def get_addr_type(addr):
 
     fqdn_flag = True
     for i in addr_list:
-        # Only Alpha-numeric characters and hyphen - RFC 1035
+        # Only Alphanumeric characters and hyphen - RFC 1035
         import re
         if not re.match("^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)?$", i):
             fqdn_flag = False
@@ -477,7 +477,7 @@ def expand_hex(hexstring, length):
     """Expand a given hexstring to a specified length by replacing "." or ".."
        with a filler that is derived from the neighboring nibbles respective
        bytes. Usually this will be the nibble respective byte before "." or
-       "..", execpt when the string begins with "." or "..", then the nibble
+       "..", except when the string begins with "." or "..", then the nibble
        respective byte after "." or ".." is used.". In case the string cannot
        be expanded for some reason, the input string is returned unmodified.
 
@@ -717,7 +717,7 @@ def decomposeATR(atr_txt):
 class DataObject(abc.ABC):
     """A DataObject (DO) in the sense of ISO 7816-4.  Contrary to 'normal' TLVs where one
     simply has any number of different TLVs that may occur in any order at any point, ISO 7816
-    has the habit of specifying TLV data but with very spcific ordering, or specific choices of
+    has the habit of specifying TLV data but with very specific ordering, or specific choices of
     tags at specific points in a stream.  This class tries to represent this."""
 
     def __init__(self, name: str, desc: Optional[str] = None, tag: Optional[int] = None):
@@ -839,7 +839,7 @@ class TL0_DataObject(DataObject):
 
 
 class DataObjectCollection:
-    """A DataObjectCollection consits of multiple Data Objects identified by their tags.
+    """A DataObjectCollection consists of multiple Data Objects identified by their tags.
     A given encoded DO may contain any of them in any order, and may contain multiple instances
     of each DO."""
 


### PR DESCRIPTION
Found via `codespell -S tests -L ist,adn,ciph,ue,ot,readd,te,oce,tye`