### PR TITLE
pcsc: fix protocol negotiation for macOS CCID driver

### DIFF
--- a/pySim/transport/pcsc.py
+++ b/pySim/transport/pcsc.py
@@ -84,21 +84,25 @@ class PcscSimLink(LinkBaseTpdu):
             # is disconnected
             self.disconnect()
 
-            # Make card connection and select a suitable communication protocol
-            self._con.connect()
-            supported_protocols = self._con.getProtocol();
-            self.disconnect()
-            if (supported_protocols & CardConnection.T0_protocol):
-                protocol =  CardConnection.T0_protocol
-                self.set_tpdu_format(0)
-            elif (supported_protocols & CardConnection.T1_protocol):
-                protocol = CardConnection.T1_protocol
-                self.set_tpdu_format(1)
-            else:
-                raise ReaderError('Unsupported card protocol')
-            self._con.connect(protocol)
-        except CardConnectionException as exc:
-            raise ProtocolError() from exc
+            # Explicitly try T=0 first, then fall back to T=1.
+            # We avoid relying on the OS driver's auto-negotiation
+            # because some drivers (notably macOS CryptoTokenKit/CCID)
+            # incorrectly negotiate T=1 for T=0-only cards.
+            # The previous approach of calling connect() without a
+            # protocol argument and then checking getProtocol() was
+            # also flawed: getProtocol() returns the negotiated protocol,
+            # not a bitmask of supported protocols, so the subsequent
+            # T=0/T=1 priority check was ineffective.
+            for protocol, tpdu_fmt in [(CardConnection.T0_protocol, 0),
+                                       (CardConnection.T1_protocol, 1)]:
+                try:
+                    self._con.connect(protocol)
+                    self.set_tpdu_format(tpdu_fmt)
+                    return
+                except CardConnectionException:
+                    self.disconnect()
+                    continue
+            raise ReaderError('Card does not support T=0 or T=1 protocol')
         except NoCardException as exc:
             raise NoCardError() from exc
 


### PR DESCRIPTION
## Summary

- Fix broken T=0/T=1 protocol selection in PcscSimLink.connect() that causes failures on macOS
- The previous code used getProtocol() (which returns the *negotiated* protocol) as if it returned *supported* protocols -- the T=0/T=1 priority logic was therefore a no-op
- On macOS, the CryptoTokenKit/CCID driver incorrectly negotiates T=1 for T=0-only cards, causing SCARD_E_NOT_TRANSACTED on every transmit() call

## Root Cause

Two independent issues combined:

1. **pySim logic bug:** getProtocol() returns the active protocol, not a bitmask of what the card supports. The code checked supported_protocols & T0_protocol but supported_protocols was always just the single negotiated value, so the check simply re-selected whatever the OS already chose.

2. **macOS driver bug:** The CryptoTokenKit CCID driver performs PPS negotiation and selects T=1 even when the card ATR only advertises T=0 (e.g., ATR with TD1=0x80 = protocol T=0 only). This is not a pySim issue per se, but the previous code had no defense against it.

## Fix

Explicitly attempt connect(T0_protocol) first, catch CardConnectionException on failure, then try connect(T1_protocol). This:
- Matches the existing intent of preferring T=0
- Removes reliance on OS driver auto-negotiation
- Is backwards-compatible: T=1-only cards fail T=0 quickly and succeed on retry

## Test Plan

- [x] Tested on macOS 15.5 (Sequoia) with ACS ACR39U ICC Reader and LTE UICC (T=0 only)
- [x] pySim-shell connects, reads IMSI/MSISDN/UST, and writes EF.MSISDN successfully
- [x] Previously failed with: CardConnectionException: Failed to transmit with protocol T1. Transaction failed. (0x80100016)