### PR TITLE
fix(ts_51_011): correct access conditions length and lifecycle decoding

### DIFF
--- a/pySim/ts_51_011.py
+++ b/pySim/ts_51_011.py
@@ -1303,13 +1303,25 @@ class CardProfileSIM(CardProfile):
                 record_len = resp_bin[14]
                 ret['file_descriptor']['record_len'] = record_len
                 ret['file_descriptor']['num_of_rec'] = ret['file_size'] // record_len
-            ret['access_conditions'] = b2h(resp_bin[8:10])
-            if resp_bin[11] & 0x01 == 0:
+            ret['access_conditions'] = b2h(resp_bin[8:11])
+            # Life cycle status
+            lcs = resp_bin[11]
+            if lcs & 0xF0:
+                ret['life_cycle_status_int'] = 'proprietary'
+            elif lcs == 0x00:
+                ret['life_cycle_status_int'] = 'no_information_given'
+            elif lcs == 0x01:
+                ret['life_cycle_status_int'] = 'creation_state'
+            elif lcs == 0x03:
+                ret['life_cycle_status_int'] = 'initialization_state'
+            elif lcs in (0x05, 0x07):
                 ret['life_cycle_status_int'] = 'operational_activated'
-            elif resp_bin[11] & 0x04:
+            elif lcs in (0x04, 0x06):
                 ret['life_cycle_status_int'] = 'operational_deactivated'
+            elif 0x0C <= lcs <= 0x0F:
+                ret['life_cycle_status_int'] = 'termination_state'
             else:
-                ret['life_cycle_status_int'] = 'terminated'
+                ret['life_cycle_status_int'] = 'rfu'
         return ret
 
     @classmethod


### PR DESCRIPTION
### Problem

The current TS 51.011 SELECT response decoding has two issues:

1. `access_conditions` is parsed incorrectly as 2 bytes instead of 3 bytes
2. `life_cycle_status_int` decoding does not follow TS 151 011 / TS 102 221

This leads to incorrect interpretation of SIM file metadata.

---

### Fix

- Fix slicing:
  - `resp_bin[8:10]` → `resp_bin[8:11]`
- Implement proper Life Cycle Status Integer (LCSI) decoding:
  - According to TS 102 221 / TS 31.101
  - Covers:
    - no information
    - creation
    - initialization
    - operational (activated/deactivated)
    - termination
    - proprietary / RFU cases

---

### Notes

- This affects the legacy TS 51.011 decoder path
- Modern TLV/FCP decoding is unaffected

---

### Validation

Tested with real SIM data:

- 'access_conditions' now correctly returned as 3 bytes
- lifecycle values now consistent with spec